### PR TITLE
Fix "OSError: [Errno 36] File name too long" for downloaded files

### DIFF
--- a/telegram_youtube_downloader/data/dl_format.py
+++ b/telegram_youtube_downloader/data/dl_format.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class DlFormat:
+    name: str
+    value: str
+    is_default: bool
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(
+            name=data.get("name", ""),
+            value=data.get("value", ""),
+            is_default=data.get("is_default", False)
+        )

--- a/telegram_youtube_downloader/data/downloader_result.py
+++ b/telegram_youtube_downloader/data/downloader_result.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class DownloaderResult:
+    file_path: str
+    video_title: str

--- a/telegram_youtube_downloader/download_thread.py
+++ b/telegram_youtube_downloader/download_thread.py
@@ -11,7 +11,7 @@ from errors.send_error import SendError
 
 
 class DownloadThread(threading.Thread):
-    def __init__(self, downloader: YoutubeDownloader, media_sender: TelegramMediaSender, url: str, chat_id: str, content_type: ContentType, dl_format_name: "str | None") -> None:
+    def __init__(self, downloader: YoutubeDownloader, media_sender: TelegramMediaSender, url: str, chat_id: int, content_type: ContentType, dl_format_name: "str | None") -> None:
         super().__init__()
         self.__logger = LoggerFactory.get_logger(self.__class__.__name__)
         self.downloader = downloader
@@ -22,36 +22,46 @@ class DownloadThread(threading.Thread):
         self.dl_format_name = dl_format_name
 
 
-    def __run_for_audio(self):
+    def __run_for_audio(self) -> None:
         download_start = time.time()
-        path = self.downloader.download(self.url, ContentType.AUDIO, self.dl_format_name)
-        self.__logger.info(f"Download completed with path {path}, took {float(time.time() - download_start):.3f} seconds")
+        result = self.downloader.download(self.url, ContentType.AUDIO, self.dl_format_name)
+        self.__logger.info(f"Download completed {result}, took {float(time.time() - download_start):.3f} seconds")
 
         self.media_sender.send_text(self.chat_id, "⬆️🎧 Download finished, sending...")
 
         upload_start = time.time()
-        self.media_sender.send_audio(chat_id=self.chat_id, file_path=path, remove=True)
+        self.media_sender.send_audio(
+            chat_id=self.chat_id,
+            file_path=result.file_path,
+            title=result.video_title,
+            remove=True
+        )
         self.media_sender.send_text(self.chat_id, "🥳")
         self.__logger.info(f"Upload completed, took {float(time.time() - upload_start):.3f} seconds")
         
         self.__logger.info(f"Total operation took {float(time.time() - download_start):.3f} seconds")
 
-    def __run_for_video(self):
+    def __run_for_video(self) -> None:
         download_start = time.time()
-        path = self.downloader.download(self.url, ContentType.VIDEO, self.dl_format_name)
-        self.__logger.info(f"Download completed with path {path}, took {float(time.time() - download_start):.3f} seconds")
+        result = self.downloader.download(self.url, ContentType.VIDEO, self.dl_format_name)
+        self.__logger.info(f"Download completed {result}, took {float(time.time() - download_start):.3f} seconds")
 
         self.media_sender.send_text(self.chat_id, "⬆️📽️ Download finished, sending...")
 
         upload_start = time.time()
-        self.media_sender.send_video(chat_id=self.chat_id, file_path=path, remove=True)
+        self.media_sender.send_video(
+            chat_id=self.chat_id,
+            file_path=result.file_path,
+            title=result.video_title,
+            remove=True
+        )
         self.media_sender.send_text(self.chat_id, "🥳")
         self.__logger.info(f"Upload completed, took {float(time.time() - upload_start):.3f} seconds")
 
         self.__logger.info(f"Total operation took {float(time.time() - download_start):.3f} seconds")
 
 
-    def run(self):
+    def run(self) -> None:
         self.__logger.info(f"Download started for url {self.url}")
 
         try:

--- a/telegram_youtube_downloader/telegram_media_sender.py
+++ b/telegram_youtube_downloader/telegram_media_sender.py
@@ -21,7 +21,7 @@ class TelegramMediaSender:
         __base_url_config = ConfigUtils.read_cfg_file()["telegram_bot_options"]["base_url"]
         self.__base_url = __base_url_config if __base_url_config is not None else self.__default_telegram_api_url
 
-    def send_text(self, chat_id, text):
+    def send_text(self, chat_id: int, text: str) -> None:
         try: 
             payload = {
                 'chat_id': chat_id,
@@ -44,14 +44,12 @@ class TelegramMediaSender:
             raise SendError()
 
 
-    def send_audio(self, chat_id, file_path, remove=False):
+    def send_audio(self, chat_id: int, file_path: str, title: str, remove=False) -> None:
         try:
-            _, file_name = os.path.split(file_path)
-
             with open(file_path, 'rb') as audio:
                 payload = {
                     'chat_id': chat_id,
-                    'title': file_name,
+                    'title': title,
                     'parse_mode': 'HTML'
                 }
                 files = {
@@ -83,14 +81,12 @@ class TelegramMediaSender:
                 folder_name, _ = os.path.split(file_path)
                 shutil.rmtree(folder_name, ignore_errors=True, onerror=None)
 
-    def send_video(self, chat_id, file_path, remove=False):
+    def send_video(self, chat_id: int, file_path: str, title: str, remove=False) -> None:
         try:
-            _, file_name = os.path.split(file_path)
-
             with open(file_path, 'rb') as video:
                 payload = {
                     'chat_id': chat_id,
-                    'title': file_name,
+                    'title': title,
                     'parse_mode': 'HTML'
                 }
                 files = {

--- a/telegram_youtube_downloader/youtube_downloader.py
+++ b/telegram_youtube_downloader/youtube_downloader.py
@@ -59,7 +59,13 @@ class YoutubeDownloader:
             # Rename
             _, file_extension = os.path.splitext(downloaded_file)
             new_file_path = os.path.join(folder_path, video_title + file_extension)
-            os.rename(downloaded_file, new_file_path)
+            try:
+                os.rename(downloaded_file, new_file_path)
+            except OSError as e:
+                if e.errno != 36:
+                    raise e
+                else:
+                    return downloaded_file
 
             return new_file_path
         except:

--- a/telegram_youtube_downloader/youtube_downloader.py
+++ b/telegram_youtube_downloader/youtube_downloader.py
@@ -5,18 +5,19 @@ import os
 
 import yt_dlp as yt
 
+from data.downloader_result import DownloaderResult
 from youtube_dl_options import YoutubeDlOptions
 from errors.download_error import DownloadError
 from utils.logger_factory import LoggerFactory
 from statics.content_type import ContentType
 from utils.config_utils import ConfigUtils
+from data.dl_format import DlFormat
 
 
 class YoutubeDownloader:
     def __init__(self) -> None:
         self.__download_options = ConfigUtils.read_cfg_file()["youtube_downloader_options"]
         self.__logger = LoggerFactory.get_logger(self.__class__.__name__)
-        self.__bad_chars = {'"': '\'', '<': '', '>': '', ':': '', '/': '', '\\': '', '|': '', '?': '', '*': ''}
 
     def __is_allowed_url(self, url: str) -> bool:
         """Checks if provided url is on the allowed url list"""
@@ -27,16 +28,10 @@ class YoutubeDownloader:
             matches.append(compiled_pattern.match(url))
         return any(matches)
 
-    def __clean_bad_chars(self, filename: str) -> str:
-        """Cleans bad chars from the path for Windows"""
-        for char in self.__bad_chars:
-            filename = filename.replace(char, self.__bad_chars[char])
-        return filename
-
-    def __rename_downloaded_file(self, video_title: str, folder_path: str) -> str:
+    def __get_downloaded_file_path(self, folder_path: str) -> str:
         """
-        Renames downloaded temp file to videos title. 
-        ** There is no (current) way to know the extension of the file that youtube_dl downloaded (also might be converted) 
+        Returns downloaded file's full path.
+        ** There is no (current) way to know the extension of the file that youtube_dl downloaded (also might be converted)
         so this function gets all files in a directory, if only 1 file exists this should be the downloaded file so it renames and returns it, else raises DownloadError
         """
 
@@ -46,33 +41,15 @@ class YoutubeDownloader:
             self.__logger.error(f"Multiple files exists in the folder '{folder_path}'")
             raise DownloadError()
 
-        downloaded_file = os.path.join(folder_path, all_files[0])
+        downloaded_file_path = os.path.join(folder_path, all_files[0])
 
-        if(not os.path.isfile(downloaded_file)):
+        if(not os.path.isfile(downloaded_file_path)):
             self.__logger.error("Downloaded file is not a valid path")
             raise DownloadError()
 
-        try:
-            # fix bad chars for windows
-            video_title = self.__clean_bad_chars(video_title)
+        return downloaded_file_path
 
-            # Rename
-            _, file_extension = os.path.splitext(downloaded_file)
-            new_file_path = os.path.join(folder_path, video_title + file_extension)
-            try:
-                os.rename(downloaded_file, new_file_path)
-            except OSError as e:
-                if e.errno != 36:
-                    raise e
-                else:
-                    return downloaded_file
-
-            return new_file_path
-        except:
-            self.__logger.error("Unknown error", exc_info=True)
-            raise DownloadError()
-
-    def __perform_download(self, url: str, options: dict) -> str:
+    def __perform_download(self, url: str, options: dict) -> DownloaderResult:
         """Download base for different content types"""
         self.__logger.info(f"Downloading from url: {url} with options: {options}")
 
@@ -88,11 +65,17 @@ class YoutubeDownloader:
 
                 # Get video info for checking duration
                 meta = ydl.extract_info(url, download=False)
+
+                if not isinstance(meta, dict):
+                    self.__logger.error("Cannot extract video metadata")
+                    raise DownloadError("Cannot extract video metadata")
+
                 max_duration = options["max_duration_seconds"]
                 content_type = options["content_type"]
+
                 duration = meta.get("duration", None)
                 if(duration is None):
-                    raise DownloadError(f"Can not get video duration")
+                    raise DownloadError(f"Cannot get video duration")
                 if(duration > max_duration):
                     raise DownloadError(f"Maximum allowed video duration for '{content_type.value}' download is {str(datetime.timedelta(seconds=max_duration))}")
 
@@ -100,9 +83,20 @@ class YoutubeDownloader:
                 meta = ydl.extract_info(url, download=True)
                 meta = ydl.sanitize_info(meta)
 
-                # Rename the temp video name with videos original title (bad windows path chars are replaced)
-                path = self.__rename_downloaded_file(meta["title"], options["save_dir"])
-                return path
+                if not isinstance(meta, dict):
+                    self.__logger.error("Cannot extract video metadata")
+                    raise DownloadError("Cannot extract video metadata")
+
+                # Get saved file path
+                downloaded_file_path = self.__get_downloaded_file_path(options["save_dir"])
+
+                # Build response
+                result = DownloaderResult(
+                    file_path=downloaded_file_path,
+                    video_title=meta.get("title", "Unknown"),
+                )
+
+                return result
 
         # Delete folder on exception
         except yt.utils.DownloadError as de:
@@ -123,21 +117,23 @@ class YoutubeDownloader:
 
 
 
-    def __get_download_format_from_name(self, content_type: ContentType, format_name: str) -> dict:
+    def __get_download_format_from_name(self, content_type: ContentType, format_name: str) -> DlFormat:
         """Returns full format dict for a format name, raises DownloadError if format is not supported. Ex: ({name: test, value: 'best/best', is_default: false})"""
         dl_formats = self.__download_options["formats"][content_type.value]
         for dl_format in dl_formats:
-            if(dl_format['name'] == format_name):
-                return dl_format
+            dl_fmt = DlFormat.from_dict(dl_format)
+            if(dl_fmt.name == format_name):
+                return dl_fmt
         self.__logger.warning(f"{content_type.value} format '{format_name}' is not supported")
         raise DownloadError(f"{content_type.value} format '{format_name}' is not supported")
 
-    def __get_default_download_format(self, content_type: ContentType) -> str:
+    def __get_default_download_format(self, content_type: ContentType) -> DlFormat:
         """Returns the default format for a content type, raises DownloadError if no default is set"""
         dl_formats = self.__download_options["formats"][content_type.value]
         for dl_format in dl_formats:
-            if(dl_format.get('is_default', False)):
-                return dl_format
+            dl_fmt = DlFormat.from_dict(dl_format)
+            if(dl_fmt.is_default):
+                return dl_fmt
         self.__logger.error(f"No default format configured for {content_type.value}")
         raise DownloadError(f"No default format configured for {content_type.value}")
 
@@ -164,7 +160,7 @@ class YoutubeDownloader:
             format_names += f"{video_format['name']}{is_default}\n"
         return format_names
 
-    def download(self, url: str, content_type: ContentType, download_format_name: "str | None") -> str:
+    def download(self, url: str, content_type: ContentType, download_format_name: "str | None") -> DownloaderResult:
         """Generic download function, sets download_format to default if download_format_name is None"""
         if(not download_format_name):
             dl_format = self.__get_default_download_format(content_type=content_type)
@@ -172,7 +168,7 @@ class YoutubeDownloader:
             dl_format = self.__get_download_format_from_name(content_type=content_type, format_name=download_format_name)
 
         options = YoutubeDlOptions()
-        options.set_format(content_type, dl_format["value"])
+        options.set_format(content_type, dl_format.value)
 
-        path = self.__perform_download(url, options.get_for_content_type(content_type))
-        return path
+        result = self.__perform_download(url, options.get_for_content_type(content_type))
+        return result


### PR DESCRIPTION
Added error handling code to check for the OSError: [Errno 36] error; if it occurs, return the original downloaded file path without renaming it.

This change prevents the script from returning an error and ensures that the download process continues smoothly even in these cases.