### PR TITLE
Provide filename when sending files to Telegram

### DIFF
--- a/telegram_youtube_downloader/telegram_media_sender.py
+++ b/telegram_youtube_downloader/telegram_media_sender.py
@@ -47,14 +47,13 @@ class TelegramMediaSender:
     def send_audio(self, chat_id: int, file_path: str, title: str, remove=False) -> None:
         try:
             with open(file_path, 'rb') as audio:
-                filename = os.path.basename(file_path)
                 payload = {
                     'chat_id': chat_id,
                     'title': title,
                     'parse_mode': 'HTML'
                 }
                 files = {
-                    'audio': (filename, audio.read()),
+                    'audio': (title, audio.read()),
                 }
                 url = f"{self.__base_url}{self.__bot_key}/sendAudio"
                 timeout = self.__telegram_options.audio_timeout_seconds
@@ -85,14 +84,13 @@ class TelegramMediaSender:
     def send_video(self, chat_id: int, file_path: str, title: str, remove=False) -> None:
         try:
             with open(file_path, 'rb') as video:
-                filename = os.path.basename(file_path)
                 payload = {
                     'chat_id': chat_id,
                     'title': title,
                     'parse_mode': 'HTML'
                 }
                 files = {
-                    'video': (filename, video.read()),
+                    'video': (title, video.read()),
                 }
                 url = f"{self.__base_url}{self.__bot_key}/sendVideo"
                 timeout = self.__telegram_options.video_timeout_seconds

--- a/telegram_youtube_downloader/telegram_media_sender.py
+++ b/telegram_youtube_downloader/telegram_media_sender.py
@@ -47,13 +47,14 @@ class TelegramMediaSender:
     def send_audio(self, chat_id: int, file_path: str, title: str, remove=False) -> None:
         try:
             with open(file_path, 'rb') as audio:
+                filename = os.path.basename(file_path)
                 payload = {
                     'chat_id': chat_id,
                     'title': title,
                     'parse_mode': 'HTML'
                 }
                 files = {
-                    'audio': audio.read(),
+                    'audio': (filename, audio.read()),
                 }
                 url = f"{self.__base_url}{self.__bot_key}/sendAudio"
                 timeout = self.__telegram_options.audio_timeout_seconds
@@ -84,13 +85,14 @@ class TelegramMediaSender:
     def send_video(self, chat_id: int, file_path: str, title: str, remove=False) -> None:
         try:
             with open(file_path, 'rb') as video:
+                filename = os.path.basename(file_path)
                 payload = {
                     'chat_id': chat_id,
                     'title': title,
                     'parse_mode': 'HTML'
                 }
                 files = {
-                    'video': video.read(),
+                    'video': (filename, video.read()),
                 }
                 url = f"{self.__base_url}{self.__bot_key}/sendVideo"
                 timeout = self.__telegram_options.video_timeout_seconds

--- a/telegram_youtube_downloader/youtube_dl_options.py
+++ b/telegram_youtube_downloader/youtube_dl_options.py
@@ -15,7 +15,7 @@ class YoutubeDlOptions:
             # Spread values from config file
             **self.__youtube_dl_options.audio_options,
 
-            "outtmpl": os.path.join(save_dir, "%(title)s.%(ext)s"),
+            "outtmpl": os.path.join(save_dir, "TEMP.%(ext)s"),
 
             # For custom downloader class 
             "content_type": ContentType.AUDIO,
@@ -27,7 +27,7 @@ class YoutubeDlOptions:
             # Spread values from config file
             **self.__youtube_dl_options.video_options,
 
-            "outtmpl": os.path.join(save_dir, "%(title)s.%(ext)s"),
+            "outtmpl": os.path.join(save_dir, "TEMP.%(ext)s"),
 
             # For custom downloader class 
             "content_type": ContentType.VIDEO,

--- a/telegram_youtube_downloader/youtube_dl_options.py
+++ b/telegram_youtube_downloader/youtube_dl_options.py
@@ -15,7 +15,7 @@ class YoutubeDlOptions:
             # Spread values from config file
             **self.__youtube_dl_options.audio_options,
 
-            "outtmpl": os.path.join(save_dir, "TEMP" + ".%(ext)s"),
+            "outtmpl": os.path.join(save_dir, "%(title)s.%(ext)s"),
 
             # For custom downloader class 
             "content_type": ContentType.AUDIO,
@@ -27,7 +27,7 @@ class YoutubeDlOptions:
             # Spread values from config file
             **self.__youtube_dl_options.video_options,
 
-            "outtmpl": os.path.join(save_dir, "TEMP" + ".%(ext)s"),
+            "outtmpl": os.path.join(save_dir, "%(title)s.%(ext)s"),
 
             # For custom downloader class 
             "content_type": ContentType.VIDEO,


### PR DESCRIPTION
Hi, thanks for your awesome project!

I've been having issues with downloading YouTube audio from Telegram to my Android device: it shows "Saved to music", yet the file doesn't appear anywhere. After spending some time researching, I noticed that on desktop, all audio from the bot is saved as "audio (x).mp3". By fixing this annoyance, I suddenly fixed my issue on Android - it seems that while Telegram Desktop was able to generate default filenames for files, uploaded as raw bytes, Telegram Android was not.

If someone encounters a similar problem in the future, I hope this fix will help

PS. I've checked this code for videos with potentially unsafe characters - it seems yt-dlp sanitizes file names to some degree to guarantee that they can be saved